### PR TITLE
I found  the DATA32 and DATAF bugs  in EV3UARTEmulationHard.cpp 

### DIFF
--- a/EV3_arduino/EV3UARTEmulation/EV3UARTEmulation.cpp
+++ b/EV3_arduino/EV3UARTEmulation/EV3UARTEmulation.cpp
@@ -128,7 +128,7 @@ void EV3UARTEmulation::send_data8(byte mode, byte b) {
 }
 
 void EV3UARTEmulation::send_data16(byte mode, short s) {
-  byte bb[1];
+  byte bb[2];
   bb[0] = s & 0xff;
   bb[1] = s >> 8;
   send_cmd(CMD_DATA | (1 << CMD_LLL_SHIFT) | mode, bb, 2);

--- a/EV3_arduino/EV3UARTEmulation/EV3UARTEmulation.h
+++ b/EV3_arduino/EV3UARTEmulation/EV3UARTEmulation.h
@@ -64,11 +64,11 @@ class EV3UARTEmulation {
 		void reset();
 		void heart_beat();
 		EV3UARTMode* get_mode(byte mode);
-		void send_data8(byte mode, byte b);
-		void send_data16(byte mode, short s);
-		void send_data16(byte mode, short *s, int len);
-		void send_data32(byte mode, long l);
-		void send_dataf(byte mode, float f);
+		void send_data8(byte b);
+		void send_data16(short s);
+		void send_data16(short *s, int len);
+		void send_data32(long l);
+		void send_dataf(float f);
 		byte get_current_mode();
 	private:
 	    SoftwareSerial* uart;

--- a/EV3_arduino/EV3UARTEmulation/examples/test/test.ino
+++ b/EV3_arduino/EV3UARTEmulation/examples/test/test.ino
@@ -16,7 +16,7 @@ byte data = 0;
 void loop() {
   sensor.heart_beat();
   if (millis() - last_reading > 100) {
-    sensor.send_data8(0, data++);
+    sensor.send_data8(data++);
     if (data > 99) data = 0;
 	last_reading = millis();
   }

--- a/EV3_arduino/EV3UARTEmulationHard/EV3UARTEmulationHard.cpp
+++ b/EV3_arduino/EV3UARTEmulationHard/EV3UARTEmulationHard.cpp
@@ -1,0 +1,282 @@
+#include "EV3UARTEmulationHard.h"
+#include <Serial.h>
+
+/**
+ * Create a mode object
+**/
+EV3UARTMode::EV3UARTMode() {
+}
+
+/**
+ * Create the sensor emulation with the specified RX and TX pins
+**/
+EV3UARTEmulation::EV3UARTEmulation(HardwareSerial *serial, byte type, unsigned long speed) {
+  uart = serial;
+  this->type = type;
+  this->speed = speed;
+  status = 0;
+  modes = 0;
+  views = 0;
+  current_mode = 0;
+}
+
+/**
+ * Define the next mode
+**/
+void EV3UARTEmulation::create_mode(String name, boolean view, 
+		                           byte data_type, byte sample_size, 
+						           byte figures, byte decimals) {
+  EV3UARTMode* mode = new EV3UARTMode();
+  mode->name = name;
+  mode->view = view;
+  mode->data_type = data_type;
+  mode->sample_size = sample_size;
+  mode->figures = figures;
+  mode->decimals = decimals;
+  mode_array[modes] = mode;
+  modes++;
+  if (view) views++;
+}	
+
+/**
+ * Get the status of the connection
+**/
+byte EV3UARTEmulation::get_status() {
+  return status;
+}
+
+/**
+ * Reset the connection
+**/
+void EV3UARTEmulation::reset () {
+  for(;;) {
+#ifdef DEBUG
+      Serial.println("Reset");
+#endif
+	  uart->begin(2400);
+	  byte b[4];
+	  b[0] = type;
+	  send_cmd(CMD_TYPE, b, 1);
+	  b[0] = modes - 1;
+	  b[1] = views - 1;
+	  send_cmd(CMD_MODES, b, 2);
+	  get_long(speed, b);
+	  send_cmd(CMD_SPEED, b, 4);
+	  for(int i=modes-1;i>=0;i--) {
+		EV3UARTMode* mode = get_mode(i);
+		byte l = mode->name.length();
+		byte ll = next_power2(l);
+		byte bb[ll+2];
+		bb[0] = 0;  // name
+		mode->name.getBytes(&bb[1],ll+1); // Leave room for null terminator
+		byte lll = log2(ll);
+		// Send name 
+		send_cmd(CMD_INFO | (lll << CMD_LLL_SHIFT) | i, bb, ll+1);
+		byte bbb[5];
+		bbb[0] = 0x80;
+		bbb[1] = mode->sample_size;
+		bbb[2] = mode->data_type;
+		bbb[3] = mode->figures;
+		bbb[4] = mode->decimals;
+		send_cmd(CMD_INFO | (2 << CMD_LLL_SHIFT) | i, bbb, 5);
+	  }
+#ifdef DEBUG
+      Serial.println("Sending ACK");
+#endif
+	  send_byte(BYTE_ACK);
+	  unsigned long m = millis();
+	  while(!uart->available() && millis() - m < ACK_TIMEOUT);
+	  if (uart->available()) {
+		byte b = uart->read();
+		if (b == BYTE_ACK) {
+		  uart->end();
+		  uart->begin(speed);
+		  delay(80);
+		  last_nack = millis();
+		  break;
+		}
+	  }
+	}
+}
+
+/**
+ * Process incoming messages
+**/
+void EV3UARTEmulation::heart_beat() {
+  if (millis() - last_nack > HEARTBEAT_PERIOD) reset();
+  if (uart->available()) {
+      byte b = uart->read();
+      if (b == BYTE_NACK) {
+#ifdef DEBUG
+        Serial.println("Received NACK");
+#endif	  
+	    last_nack = millis();
+	  } else {
+#ifdef DEBUG
+        Serial.print("Received: ");
+		Serial.println(b, HEX);
+#endif	
+         if (b == CMD_SELECT) {
+#ifdef DEBUG
+        Serial.println("Received SELECT ");
+#endif
+		   byte checksum = 0xff ^ b;
+		   byte mode = read_byte();
+		   checksum ^= mode;
+		   if (checksum == read_byte()) {
+#ifdef DEBUG
+        Serial.print("Mode is ");
+		Serial.println(mode);
+#endif
+		     if (mode < modes) current_mode = mode;
+		   }
+		 }
+      } 
+  }
+}
+
+/**
+ * Get the mode object for a specific mode.
+**/
+EV3UARTMode* EV3UARTEmulation::get_mode(byte mode) {
+  return mode_array[mode];
+}	
+
+/**
+ * Send a single byte t the EV3, as data.
+**/
+void EV3UARTEmulation::send_data8(byte b) {
+  byte bb[1];
+  bb[0] = b;
+  
+  send_cmd(CMD_DATA | current_mode, bb, 1);
+}
+
+/**
+ * Send a single short to the EV3
+**/
+void EV3UARTEmulation::send_data16(short s) {
+  byte bb[2];
+  bb[0] = s & 0xff;
+  bb[1] = s >> 8;
+  send_cmd(CMD_DATA | (1 << CMD_LLL_SHIFT) | current_mode, bb, 2);
+}	
+
+/**
+ * Send an array of shorts to the EV3 as data.
+ * len must be a power of 2
+**/
+void EV3UARTEmulation::send_data16(short* s, int len) {
+  byte bb[len*2];
+  for(int i=0;i<len;i++) {
+    bb[2*i] = s[i] & 0xff;
+    bb[2*i+1] = s[i] >> 8;   
+  }
+  send_cmd(CMD_DATA | (log2(len*2) << CMD_LLL_SHIFT) | current_mode, bb, len*2);
+}
+
+/**
+ * Send a long to the EV3 as data
+**/
+void EV3UARTEmulation::send_data32(long l) {
+  byte bb[4];
+  for(int i=0;i<4;i++) {
+    bb[i] = (l >> (i * 8)) && 0xff;
+  }
+  send_cmd(CMD_DATA | (2 << CMD_LLL_SHIFT) | current_mode, bb, 4);
+}
+
+/**
+ * Send a float to the EV3 as data
+**/
+void EV3UARTEmulation::send_dataf(float f) {
+  union Data {
+    unsigned long l;
+    float f;
+  } data;
+  data.f = f;
+  send_data32(data.l);
+}			
+
+/**
+ * Send a command to the  EV3
+**/
+void EV3UARTEmulation::send_cmd(byte cmd, byte* data, byte len) {
+  byte checksum = 0xff ^ cmd;
+#ifdef DEBUG
+      Serial.print("Cmd: ");
+	  Serial.print(cmd, HEX);
+	  Serial.print(" ");
+#endif
+  uart->write(cmd);
+  for(int i=0;i<len;i++) {
+    checksum ^= data[i];
+#ifdef DEBUG
+      Serial.print(data[i],HEX);
+	  Serial.print(" ");
+#endif
+    uart->write(data[i]);
+  }
+  uart->write(checksum);
+#ifdef DEBUG
+      Serial.println(checksum, HEX);
+#endif
+}
+
+/**
+ * Write a single byte to the EV3
+**/
+void EV3UARTEmulation::send_byte(byte b) {
+  uart->write(b);
+}
+
+/**
+ * Utility method to copy a long into a byte array
+**/
+void EV3UARTEmulation::get_long(unsigned long l, byte* bb) {
+  for(int i=0;i<4;i++) {
+    bb[i] = (l >> (i * 8)) & 0xff;
+  }
+}
+
+/**
+ * Utility method to return a small power of 2
+**/
+int EV3UARTEmulation::log2(int val) {
+  switch(val) {
+    case 1: return 0;
+    case 2: return 1;
+    case 4: return 2;
+    case 8: return 3;
+    case 16: return 4;
+    case 32: return 5;
+    default: return 0;
+  }
+}
+
+/**
+ * Utility method to return the next power of 2 (up to 32)
+**/
+int EV3UARTEmulation::next_power2(int val) {
+  if (val == 1 || val == 2) return val;
+  else if (val <= 4) return 4;
+  else if (val <= 8) return 8;
+  else if (val <= 16) return 16;
+  else if (val <= 32) return 32;
+  else return 0;
+}
+
+/**
+ * Utility method to read a byte synchronously
+**/
+byte EV3UARTEmulation::read_byte() {
+  while(!uart->available());
+  return uart->read();
+}
+
+/**
+ * Get the current mode
+**/
+byte EV3UARTEmulation::get_current_mode() {
+  return current_mode;
+}

--- a/EV3_arduino/EV3UARTEmulationHard/EV3UARTEmulationHard.h
+++ b/EV3_arduino/EV3UARTEmulationHard/EV3UARTEmulationHard.h
@@ -1,0 +1,89 @@
+// EV3UARTEmulation.h
+//
+// Emulation of LEGO Mindstorms EV3 UART protocol for creating your own sensors
+// 
+// Author: Lawrie Griffiths (lawrie.griffiths@ntlworld.com)
+// Copyright (C) 2014 Lawrie Griffiths
+
+#include <Arduino.h>
+#include <Serial.h>
+
+#define   BYTE_ACK                      0x04
+#define   BYTE_NACK                     0x02
+#define   CMD_TYPE                      0x40
+#define   CMD_SELECT                    0x43
+#define   CMD_MODES                     0x49
+#define   CMD_SPEED                     0x52
+#define   CMD_MASK                      0xC0
+#define   CMD_INFO                      0x80
+#define   CMD_LLL_MASK                  0x38
+#define   CMD_LLL_SHIFT                 3
+#define   CMD_MMM_MASK                  0x07
+#define   CMD_DATA                      0xc0
+
+#define   DATA8                         0
+#define   DATA16                        1
+#define   DATA32                        2
+#define   DATAF                         3
+
+#define   ACK_TIMEOUT                   1000
+#define   HEARTBEAT_PERIOD              10000
+
+// Maximum number of modes supported
+#define   MAX_MODES                     10
+
+// Set for message debugging
+//#define DEBUG
+
+/**
+* Represent a specific sensor mode
+**/
+class EV3UARTMode {
+	public:
+		EV3UARTMode();
+		String name;                      // The mode name
+		String symbol;                    // The unit symbol
+		byte sample_size;                 // The number of samples
+		byte data_type;                   // The data type 0= 8bits, 1=16 bits, 2=32 bits, 3=float
+		byte figures;                     // Number of significant digits
+		byte decimals;                    // Number of decimal places
+		float raw_low, raw_high;          // Low and high values for raw data
+		float si_low, si_high;            // Low and high values for SI data
+		float pct_low, pct_high;	      // Low and high values for Percentage values
+		boolean view;                     // Indicates if this mode is a view
+		String get_data_type_string();    // Get the data type as a string
+};
+
+class EV3UARTEmulation {
+	public:
+	    EV3UARTEmulation(HardwareSerial *serial, byte type, unsigned long speed);
+		void create_mode(String name, boolean view, 
+		                 byte data_type, byte sample_size, 
+						 byte figures, byte decimals);
+		byte get_status();
+		void reset();
+		void heart_beat();
+		EV3UARTMode* get_mode(byte mode);
+		void send_data8(byte b);
+		void send_data16(short s);
+		void send_data16(short *s, int len);
+		void send_data32(long l);
+		void send_dataf(float f);
+		byte get_current_mode();
+	private:
+	    HardwareSerial *uart;
+		byte modes;
+		byte views;
+		byte type;
+        byte status;
+		unsigned long speed;
+		byte current_mode;
+		void send_cmd(byte cmd, byte* data, byte len);
+		void send_byte(byte b);	
+		EV3UARTMode* mode_array[MAX_MODES];                // An array of EV3UARTMode objects
+		unsigned long last_nack;
+		void get_long(unsigned long l, byte *bb);          // Helper method to get a long value
+		int log2(int val);                                 // Helper method for log 2
+		int next_power2(int val);
+	    byte read_byte();                                  // Read a byte from the sensor (synchronous)
+};

--- a/EV3_arduino/EV3UARTEmulationHard/ev3nose/ev3nose.ino
+++ b/EV3_arduino/EV3UARTEmulationHard/ev3nose/ev3nose.ino
@@ -1,0 +1,24 @@
+#include <EV3UARTEmulationHard.h>
+#include <Serial.h>
+
+EV3UARTEmulation sensor(&Serial1, 99, 38400);
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial1);
+  sensor.create_mode("TEST", true, DATA16, 1, 3, 0);
+  sensor.reset();
+}
+
+unsigned long last_reading = 0;
+
+void loop() {
+  sensor.heart_beat();
+  if (millis() - last_reading > 100) {
+    int r = analogRead(0);
+    sensor.send_data16(r);
+    Serial.print("Reading: ");
+    Serial.println(r);
+    last_reading = millis();
+  }
+}

--- a/EV3_arduino/EV3UARTSensorMega/EV3UARTSensorMega.cpp
+++ b/EV3_arduino/EV3UARTSensorMega/EV3UARTSensorMega.cpp
@@ -1,0 +1,518 @@
+// EV3UARTSensor.c
+//
+// Interface to LEGO Mindstorms EV3 UART Sensors
+// 
+// Author: Lawrie Griffiths (lawrie.griffiths@ntlworld.com)
+// Copyright (C) 2014 Lawrie Griffiths
+
+#include "EV3UARTSensorMega.h"
+#include <Serial.h>
+
+/**
+ * Create a mode object
+**/
+EV3UARTMode::EV3UARTMode() {
+}
+
+/**
+ * Get the mode data type as a string
+**/
+String EV3UARTMode::get_data_type_string() {
+  switch(data_type) {
+    case 0: return "Data8";
+    case 1: return "Data16";
+    case 2: return "Data32";
+    case 3: return "DataF";
+    default: return "Invalid";
+  }
+}
+
+/**
+ * Create the sensor with the specified RX and TX pins
+ * Speed starts at 2400 baud
+**/
+EV3UARTSensor::EV3UARTSensor(HardwareSerial *serial) {
+  ss = serial;
+  status = RESET;
+  speed = 2400;
+  mode = -1;
+  num_samples = 1;
+}
+
+/**
+ * Get the mode object for a specific mode
+**/
+EV3UARTMode* EV3UARTSensor::get_mode(int mode) {
+  return mode_array[mode];
+}
+
+/**
+ * Start communication with the sensor
+**/
+void EV3UARTSensor::begin() {
+  ss->begin(2400);
+}
+
+/**
+ * End communication with the sensor
+**/
+void EV3UARTSensor::end() {
+  ss->end();
+}
+
+/**
+ * Reset the sensor. It will revert to mode zero.
+**/
+void EV3UARTSensor::reset() {
+  status = RESET;
+  speed = 2400;
+  ss->end();
+  ss->begin(2400);
+}
+
+/**
+ * This does most of the work. Must be called very frequently. The metadata is processed and the mode objects created.
+ * When this is complete, the bit rate is increased and the data is processed.
+**/
+void EV3UARTSensor::check_for_data() {
+  // Send heart beat messages if in data mode
+  if (this->status == DATA_MODE && (millis() - this->last_nack) > HEART_BEAT) {
+    ss->write(BYTE_NACK);
+    this->last_nack = millis();
+  } 
+  
+  // Process bytes from the sensor
+  if (ss->available()) {
+    byte cmd = ss->read();
+	
+	if (this->status == DATA_MODE) {
+#ifdef DEBUG
+	  Serial.print("Data received ");
+      Serial.println(cmd, HEX);
+#endif	 
+      // If in data mode, process the data command and set the current value(s)
+      if ((cmd & CMD_MASK) == CMD_DATA) {
+        byte lll = (cmd & CMD_LLL_MASK) >> CMD_LLL_SHIFT;
+        byte l = this->exp2(lll); // Number of extra bytes
+        byte mode = (cmd & 7); // The current mode
+        byte checksum = 0xff ^ cmd;
+        byte bb[l];
+#ifdef DEBUG
+		Serial.print("Data message: mode: ");
+		Serial.print(mode);
+		Serial.print(" length: ");
+		Serial.println(l);
+#endif
+        for(int i=0;i<l;i++) {
+          bb[i] = this->read_byte();
+          checksum ^= bb[i];
+        }
+		byte sum = this->read_byte();
+		// The Color sensor calculates checksums incorrectly in RGB mode
+        if ((this->type == TYPE_COLOR && mode == 4) || checksum == sum) {
+		  this->consecutive_errors = 0;
+		  recent_messages++;
+		  // Extract the data from the message using type information from INFO messages
+		  for(int i=0;i<num_samples;i++) {
+		    switch(mode_array[mode]->data_type) {
+		      case 0: this->value[i] = (float) bb[i]; break;
+              case 1: this->value[i] = (float) get_int(bb,i*2); break;
+              case 2: this->value[i] = (float) get_long(bb,i*4); break;
+              case 3: this->value[i] = get_float(bb,i*4); break;
+			}
+		  }
+#ifdef DEBUG
+        Serial.print("Valid data message : ");
+        Serial.print("Data is ");
+        Serial.println(this->value[0]);
+#endif
+        } else {
+#ifdef DEBUG
+          Serial.println("Data checksum error");
+		  Serial.print("  Message: ");
+		  Serial.print(cmd,HEX);
+		  Serial.print(" ");
+		  for(int  i=0;i<l;i++) {
+		    Serial.print(bb[i],HEX);
+			Serial.print(" ");
+	      }
+		  Serial.print("  Calculated: ");
+		  Serial.print(checksum, HEX);
+		  Serial.print("  Received: ");
+		  Serial.println(sum, HEX);
+#endif	  
+		  this->data_errors++;
+		  // If more than 6 errors occur in a row, reset the connection
+		  if (this->consecutive_errors++ > 60) reset();
+        }
+	  }
+	  // Ignore all messages except CMD_TYPE until we get a valid CMD_TYPE message
+	} else if (this->status == STARTED || cmd == CMD_TYPE) {
+	  if (cmd == BYTE_ACK) {
+	    // Ack receive
+#ifdef DEBUG
+		Serial.println("Ack received");
+		Serial.print("Setting speed to: ");
+        Serial.println(this->speed);
+#endif
+        // An ACK is sent by the sensor after all the metadata is sent
+		// Send an ACK back, wait a while, and then change the speed
+		// to the one given in the CMD_SPEED message
+        ss->write(BYTE_ACK);
+        delay(100);
+        ss->end();
+        ss->begin(speed); 
+		// We are now in data mode. Set the mode to zero 
+		// and initialize some counters
+        this->set_mode(0); 
+        this->last_nack = millis();
+        this->status = DATA_MODE;
+		this->data_errors = 0;
+		this->consecutive_errors = 0;
+		this->recent_messages = 0;
+	  } else if (cmd == CMD_TYPE) {
+#ifdef DEBUG
+	    Serial.println("Type command");
+#endif
+        // Tpe command is the first metadata command. Extract the type field
+        byte checksum = 0xff ^ cmd;
+        byte type = this->read_byte();
+        checksum ^= type;
+        if (checksum == this->read_byte()) {
+		  this->type = type;
+          this->status = STARTED;
+#ifdef DEBUG
+		  Serial.print("Valid type message : ");
+		  Serial.println(type);
+#endif		  
+        } else {
+#ifdef DEBUG		
+		  Serial.println("Type invalid checksum");
+#endif
+		}
+	  } else if (cmd == CMD_MODES) {
+	    // The mode command comes after the type command.
+		// Extract the number of modes and views
+        byte checksum = 0xff ^ cmd;
+        byte modes = this->read_byte();
+        checksum ^= modes;
+        byte views = this->read_byte();
+        checksum ^= views;
+        if (checksum == this->read_byte()) {
+		  this->views = views;
+		  this->modes = modes + 1;
+		  // Create a mode object for each of the modes
+		  for(int i =0;i<=modes && i < MAX_MODES;i++) {
+		    this->mode_array[i] = new EV3UARTMode();;
+		  }
+#ifdef DEBUG
+          Serial.print("Valid modes message: ");
+          Serial.print("modes = ");
+          Serial.print(modes);
+          Serial.print(" views = ");
+          Serial.println(views);
+#endif
+        } else {
+#ifdef DEBUG
+          Serial.println("Invalid modes checksum");
+#endif		  
+        }
+	  } else if (cmd == CMD_SPEED) {
+	    // The speed command comes after the MODES command
+		// Extract the bit rate to use in data mode
+        byte checksum = 0xff ^ cmd;
+        byte bb[4];
+        for(int i=0;i<4;i++) {
+          byte b = this->read_byte();
+          checksum ^= b;
+          bb[i] = b;
+        }
+        if (checksum == this->read_byte()) {
+	      this->speed  = this->get_long(bb, 0);
+#ifdef DEBUG		  
+          Serial.print("Valid speed message: ");
+          Serial.print("Speed: ");
+          Serial.println(speed);
+#endif		  
+        } else {
+          Serial.println("Invalid speed checksum");
+        }
+	  } else if ((cmd & CMD_MASK) == CMD_INFO) {
+#ifdef DEBUG
+        Serial.print("Info message: ");
+#endif
+        // A series of INFO commands are given for each mode
+		// Modes count down from the highest to zero
+        byte lll = (cmd & CMD_LLL_MASK) >> CMD_LLL_SHIFT;
+        byte l = this->exp2(lll);
+        byte mode = (cmd & CMD_MMM_MASK);
+        byte checksum = 0xFF ^ cmd;
+        byte type = this->read_byte();
+        checksum ^= type;
+        byte bb[l];
+        for(int i=0;i<l;i++) {
+          byte b = this->read_byte();
+          checksum ^= b;
+          bb[i] = b;
+        } 
+		String modeName, symbol;
+		float low, high;
+        if (checksum != this->read_byte()) {
+          Serial.print("Invalid info checksum");
+        } else {
+          switch(type) {
+            case 0:
+			    // The mode name
+			    modeName = this->get_string(bb,l);
+				this->mode_array[mode]->name = modeName;
+#ifdef DEBUG
+              Serial.print("Name: ");
+              Serial.println(modeName);
+#endif			  
+              break;
+            case 1:
+			  // The range of raw values
+			  low = this->get_float(bb,0);
+			  high = this->get_float(bb,4);
+			  mode_array[mode]->raw_low = low;
+			  mode_array[mode]->raw_high = high;
+#ifdef DEBUG			
+              Serial.print("Raw: ");
+              Serial.print(low);
+              Serial.print(" ");
+              Serial.println(high);
+#endif			  
+              break;
+            case 2:
+			  // The range of percentage values
+			  low = this->get_float(bb,0);
+			  high = this->get_float(bb,4);
+			  mode_array[mode]->pct_low = low;
+			  mode_array[mode]->pct_high = high;
+#ifdef DEBUG			
+              Serial.print("Pct: ");
+              Serial.print(low);
+              Serial.print(" ");
+              Serial.println(high);
+#endif			  
+              break;        
+            case 3:
+			  // The range of SI values
+			  low = this->get_float(bb,0);
+			  high = this->get_float(bb,4);
+			  mode_array[mode]->si_low = low;
+			  mode_array[mode]->si_high = high;
+#ifdef DEBUG			
+              Serial.print("Si: ");
+              Serial.print(low);
+              Serial.print(" ");
+              Serial.println(high);
+#endif			  
+              break;
+            case 4:
+			  // The unit symbol
+			  symbol = this->get_string(bb,l);
+			  mode_array[mode]->symbol = symbol;
+#ifdef DEBUG			
+              Serial.print("Symbol: ");
+              Serial.println(symbol);
+#endif			  
+              break;
+            case 0x80:
+			  // The data format including number of data items,
+			  // the data time and the number of signicant digits
+			  mode_array[mode]->sets = bb[0];
+			  mode_array[mode]->data_type = bb[1];
+			  mode_array[mode]->figures = bb[2];
+			  mode_array[mode]->decimals = bb[3];
+#ifdef DEBUG			
+              Serial.print("Format: ");
+              Serial.print(" Sets: ");
+              Serial.print(bb[0]);
+              Serial.print(" Data Type: ");
+              Serial.print(this->get_data_type(bb[1]));
+              Serial.print(" ");
+              Serial.print(" Figures: ");
+              Serial.print(bb[2]);
+              Serial.print(" Decimals: ");
+              Serial.print(bb[3]); 
+			  // After a format commmand for mode 0 is given, an ACK will be sent
+			  // and we reply to it, change the speed, and go into data mode.
+              Serial.print(" Mode ");
+              Serial.println(mode);
+#endif         
+             break;
+          }
+        }
+	  }
+	}
+  }
+}
+
+/**
+ * Utility method to read a byte synchronously
+**/
+byte EV3UARTSensor::read_byte() {
+  while(!ss->available());
+  return ss->read();
+}
+
+/**
+ * Utility method to read a long from a byte array
+**/
+unsigned long EV3UARTSensor::get_long(byte* bb, int offset) {
+   return ((unsigned long) bb[offset]) | ((unsigned long) bb[offset+1] << 8) | 
+         ((unsigned long) bb[offset+2] << 16) | ((unsigned long) bb[offset+3] << 24); 
+}
+
+/**
+ * Utility method to get a string from a byte array
+**/
+String EV3UARTSensor::get_string(byte* bb, int len) {
+  String s = "";
+  for(int i=0;i<len;i++) {
+    if (bb[i] == 0) break;
+    s += (char) bb[i];
+  }
+  return s;
+}
+
+/**
+ * Utility method to get a float from a byte array
+**/
+float EV3UARTSensor::get_float(byte *bb, int offset) {
+  union Data {
+    unsigned long l;
+    float f;
+  } data;
+  
+  data.l = this->get_long(bb,offset);
+  return data.f;
+}
+
+/**
+ * Utility method to get an int from a byte array
+**/
+int EV3UARTSensor::get_int(byte* bb, int offset) {
+  return ((int) bb[offset]) | ((int) bb[offset+1] << 8);
+}
+
+/**
+ * Utility method t return a small power of 2
+**/
+int EV3UARTSensor::exp2(int val) {
+  switch(val) {
+    case 0: return 1;
+    case 1: return 2;
+    case 2: return 4;
+    case 3: return 8;
+    case 4: return 16;
+    case 5: return 32;
+    default: return 0;
+  }
+}
+
+/**
+ * Debugging method to convert INFO message type to a string
+**/
+String EV3UARTSensor::get_info_type(int val) {
+  switch(val) {
+    case 0: return "Name";
+    case 1: return "Raw";
+    case 2: return "Pct";
+    case 3: return "Si";
+    case 4: return "Symbol";
+    case 0x80: return "Format";
+    default: return "Invalid";
+  }
+}
+
+/**
+ * Utility method to convert a data type to a string
+**/  
+String EV3UARTSensor::get_data_type(int val) {
+  switch(val) {
+    case 0: return "Data8";
+    case 1: return "Data16";
+    case 2: return "Data32";
+    case 3: return "DataF";
+    default: return "Invalid";
+  }
+}
+
+/**
+ * Set the sensor mode
+**/
+void EV3UARTSensor::set_mode(int mode) {
+  this->send_select(mode);
+  this->mode = mode;
+  this->num_samples = mode_array[mode]->sets;
+}
+
+/**
+ * Send mode select command to the sensor
+**/
+void EV3UARTSensor::send_select(byte mode) {
+  byte checksum = 0xff ^ CMD_SELECT;
+  ss->write(CMD_SELECT);
+  ss->write(mode);
+  checksum ^= mode;
+  ss->write(checksum);
+}
+
+/**
+ * Send a write command command to the sensor
+**/
+void EV3UARTSensor::send_write(byte* bb, int len) {
+  byte b = CMD_WRITE | (len << CMD_LLL_SHIFT);
+  byte checksum = 0xFF ^ b;
+  ss->write(b);
+  for(int i=0;i<len;i++) {
+    ss->write(bb[i]);
+	checksum ^= bb[i];
+  }
+  ss->write(checksum);
+}
+
+/**
+ * Return the sample size for the current mode
+**/
+int EV3UARTSensor::sample_size() {
+  return this->num_samples;
+}
+
+/**
+ * Get the current sensor mode
+**/
+int EV3UARTSensor::get_current_mode() {
+  return this->mode;
+}
+
+/**
+ * Get the number of sensor modes
+**/
+int EV3UARTSensor::get_number_of_modes() {
+  return this->modes;
+}
+
+/**
+ * Get the sensor type
+**/
+int EV3UARTSensor::get_type() {
+  return this->type;
+}
+
+/**
+ * Get the status of the connection
+**/
+int EV3UARTSensor::get_status() {
+  return this->status;
+}
+
+/**
+ * Fetch a sample in the current mode
+**/
+void EV3UARTSensor::fetch_sample(float* sample, int offset) {
+  for(int i=0;i<num_samples;i++) sample[offset+i] = this->value[i];
+}
+

--- a/EV3_arduino/EV3UARTSensorMega/EV3UARTSensorMega.h
+++ b/EV3_arduino/EV3UARTSensorMega/EV3UARTSensorMega.h
@@ -1,0 +1,106 @@
+// EV3UARTSensor.h
+//
+// Interface to LEGO Mindstorms EV3 UART Sensors
+// 
+// Author: Lawrie Griffiths (lawrie.griffiths@ntlworld.com)
+// Copyright (C) 2014 Lawrie Griffiths
+
+#include <Arduino.h>
+#include <Serial.h>
+
+// Message values
+#define   BYTE_ACK                      0x04
+#define   BYTE_NACK                     0x02
+#define   CMD_SELECT                    0x43
+#define   CMD_TYPE                      0x40
+#define   CMD_MODES                     0x49
+#define   CMD_SPEED                     0x52
+#define   CMD_MASK                      0xC0
+#define   CMD_INFO                      0x80
+#define   CMD_LLL_MASK                  0x38
+#define   CMD_LLL_SHIFT                 3
+#define   CMD_MMM_MASK                  0x07
+#define   CMD_DATA                      0xc0
+#define   CMD_WRITE                     0x44
+
+#define   TYPE_COLOR                    29
+
+// Values for status
+#define RESET 0
+#define STARTED 1
+#define DATA_MODE 2
+
+// Maximum number of modes supported
+#define MAX_MODES 10
+
+// The maximum number of data items in a sample
+#define MAX_DATA_ITEMS 10
+
+// The time between heartbeats in milliseconds
+#define HEART_BEAT 100
+
+// Set to get message debbugging
+//#define DEBUG
+
+/**
+* Represent a specific sensor mode
+**/
+class EV3UARTMode {
+	public:
+		EV3UARTMode();
+		String name;                      // The mode name
+		String symbol;                    // The unit symbol
+		byte sets;                        // The number of samples
+		byte data_type;                   // The data type 0= 8bits, 1=16 bits, 2=32 bits, 3=float
+		byte figures;                     // Number of significant digits
+		byte decimals;                    // Number of decimal places
+		float raw_low, raw_high;          // Low and high values for raw data
+		float si_low, si_high;            // Low and high values for SI data
+		float pct_low, pct_high;	      // Low and high values for Percentage values
+		String get_data_type_string();    // Get the data type as a string
+};
+
+/**
+* Represent a generic EV3 UART Sensor
+**/
+class EV3UARTSensor {
+	public:
+		EV3UARTSensor(HardwareSerial* serial);         // Create the sensor and specify the pins for SoftwareSerial
+		void begin();                                  // Start communicating with the sensor
+		void end();                                    // End communication with      
+		void check_for_data();                         // Called from Arduino loop to process all data from the sensor
+		int get_number_of_modes();                     // Number of modes supported
+		void set_mode(int mode);                       // Set the sensor to the specific mode
+		int get_current_mode();                        // The current sensor mode
+		int sample_size();                             // The number of items in a sample for the current mode
+		void fetch_sample(float* sample, int offset);  // Fetch a sample in the current mode
+		int get_status();                              // Get the status of the connection
+		EV3UARTMode* get_mode(int mode);               // Get the EV3UARTMode object for a specific mode
+		void reset();                                  // Make the sensor reset
+		void send_write(byte* bb, int len);            // Send a WRITE command to the sensor
+		int get_type();                                // Get the LEGO type code for the sensor
+	private:
+	    byte read_byte();                              // Read a byte from the sensor (synchronous)
+		unsigned long get_long(byte* bb, int offset);  // Helper method to get a long value
+		String get_string(byte* bb, int len);          // Helper method to get a String value
+		float get_float(byte* bb, int len);            // Helper method to get a float value
+		int exp2(int val);                             // Helper method for powers of 2
+		String get_info_type(int val);                 // Helper method to get type of INFO message
+		String get_data_type(int val);                 // Helper method to get the data type as a string
+		void send_select(byte mode);                   // Send a CMD_SELECT command t change modes
+		int get_int(byte* bb, int offset);             // Helper method to get an int
+		unsigned long speed;                           // The required bit rate of the sensor
+		byte mode;                                     // The current sensor mode
+		byte status;                                   // The current status of the connection
+		byte modes;                                    // The number of modes supported
+		byte views;                                    // The number of views supported
+		unsigned long last_nack;                       // The time of the last heartbeat NACK
+		byte type;                                     // The internal type encoding of the sensor
+		HardwareSerial *ss;                            // Reference to the SoftwareSerial object
+		int data_errors;                               // Total number of data errors
+		float value[MAX_DATA_ITEMS];                   // The current value
+		int num_samples;                               // The current number of samples
+		EV3UARTMode* mode_array[MAX_MODES] ;           // An array of EV3UARTMode objects
+		byte consecutive_errors;                       // Number of sonsective errors
+		int recent_messages;                           // Number of recent messages
+};


### PR DESCRIPTION
I found  DATA32 and DATAF bugs in EV3UARTEmulationHard.cpp and  EV3UARTEmulationHard.cpp and change your code.

`The` conversion in DATA32  from long to array of bytes is wrong, so also the DATAF is wrong, because that uses the DATA32 send. 

**Code was:** 
void EV3UARTEmulation::send_data32(long l) {
  byte bb[4];
  bb[0] = l & 0xFF;
  bb[1] = (l >> 8) & 0xFF;
  bb[2] = (l >> 16) & 0xFF;
  bb[3] = (l >> 24) & 0xFF;
  send_cmd(CMD_DATA | (2 << CMD_LLL_SHIFT) | current_mode, bb, 4);
}


**I changed it into:** 
void EV3UARTEmulation::send_data32(long l) {
  byte bb[4];
  bb[0] = l & 0xFF;
  bb[1] = (l >> 8) & 0xFF;
  bb[2] = (l >> 16) & 0xFF;
  bb[3] = (l >> 24) & 0xFF;
  send_cmd(CMD_DATA | (2 << CMD_LLL_SHIFT) | current_mode, bb, 4);
}






